### PR TITLE
Add support for reading and writing bits. Add support for reading multiple memory ares. Migrate to safe Buffer constructor methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ This is an implementation of the [OMRON FINS protocol](https://www.google.com/se
 ### Supported Commands:
 
 * Memory area read
+* Multiple memory area read
 * Memory area write
 * Memory area fill
+* Memory area transfer
 * Controller status read
 * Run
 * Stop
@@ -86,6 +88,17 @@ client.read('D00000',10,function(err,bytes) {
 });
 ```
 
+##### .readMultiple(address(es))
+Multiple Memory Area Read Command 
+* `address` - Memory area and the numerical start address
+
+```js
+ /* Reads multiple registers from different memory areas, you can mix and match words and bit reads. 
+    Does not currently support callback  */
+.readMultiple('D100','H10','CB80:03','H22');
+
+```
+
 ##### .write(address, dataToBeWritten, callback)
 Memory Area Write Command
 * `address` - Memory area and the numerical start address
@@ -95,16 +108,41 @@ Memory Area Write Command
 /* Writes single value of 1337 into DM register 00000 */
 .write('D00000',1337)
 
+/* Writes 1 to bit 3 of HB register 50 */
+.write('HB50:03',1)
+
 /* Writes the values 12,34,56 into DM registers 00000 00001 000002 */
 .write('D00000',[12,34,56]);
-
 
 /* Same as above with callback */
 .write('D00000',[12,34,56],function(err,bytes) {
 	console.log("Bytes: ", bytes);
 });
+
+/* Writes 1 to bits 3,4 & 5 of HB register 50 */
+.write('HB50:03',[1,1,1])
+
 ```
 
+##### .transfer(soureceAddress, destAddress, regsToBeWritten, callback)
+Memory Area Transfer Command
+* `sourceAddress` - Memory area and the numerical start address of the source
+* `destAddress` - Memory area and the numerical start address of the destination
+* `regsToBeWritten` - Number of registers to write
+* `callback` - Optional callback method
+```js
+
+/* Transfers 10 consecutive DM registers from 50 to 100 */
+.fill('D50','D100',10);
+
+
+/* Sames as above with callback */
+.fill('D50','D100',10,function(err,bytes) {
+	console.log("Bytes: ", bytes); 
+});
+
+
+```
 ##### .fill(address, dataToBeWritten, regsToBeWritten, callback)
 Memory Area Fill Command
 * `address` - Memory area and the numerical start address

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -14,7 +14,7 @@ client.on('error',function(error) {
 */
 
 client.on('reply',function(msg) {
-  console.log("Reply from: ", msg.remotehost);
+    console.log("Reply from: ", msg.remotehost);
     console.log("Replying to issued command of: ", msg.command);
     console.log("Response code of: ", msg.code);
     console.log("Data returned: ", msg.values);
@@ -24,12 +24,26 @@ client.on('reply',function(msg) {
 /* Read 10 registers starting at DM register 00000 */
 client.read('D00000',10,function(err,bytes) {
 	console.log("Bytes: ", bytes);
-
 });
+
+/* Read CIO bit 1.00 */
+client.read('CB1:00',1,function(err,bytes) {
+	console.log("Bytes: ", bytes);
+});
+
+/* Read WORDS or BITS from multiple memory address in one command */
+client.readMultiple('H18','W32','H20','CB80:03','H22');
 
 /* Write 1337 to DM register 00000 */
 client.write('D00000',1337)
 
+/* Write 1 to bit 3 HB register 50 */
+client.write('HB50:03',1)
 
 /* Write 12,34,56 in DM registers 00000 00001 00002 */
 client.write('D00000',[12,34,56]);
+
+/* Transfer 10 registers starting at H500 to H1000 */
+client.transfer('H500','H1000',10,function(err,bytes) {
+        console.log("Bytes: ", bytes);
+});

--- a/examples/multpleClients.js
+++ b/examples/multpleClients.js
@@ -8,7 +8,7 @@ var clients = [];
 /* Hold both successful and failed communication attempts */
 var responses = [];
 
-/* 
+/*
     List of remote hosts
     More than likely will be generated from external source
 */
@@ -17,7 +17,7 @@ var remoteHosts = ['127.0.0.1','127.0.0.2','127.0.0.3'];
 
 
 /*
-    This method will be executed once we know all communications 
+    This method will be executed once we know all communications
     have either timed out or responded accordingly. This is where
     data will be processed (database,api,etc)
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -29,6 +29,8 @@ module.exports.Commands = {
     MEMORY_AREA_READ       : [0x01,0x01],
     MEMORY_AREA_WRITE      : [0x01,0x02],
     MEMORY_AREA_FILL       : [0x01,0x03],
+    MEMORY_AREA_READ_MULTI : [0x01,0x04],
+    MEMORY_AREA_TRANSFER   : [0x01,0x05],
     RUN                    : [0x04,0x01],
     STOP                   : [0x04,0x02]
 };
@@ -65,12 +67,17 @@ module.exports.Modes = {
 
 
 module.exports.MemoryAreas = {
-    'E' : 0xA0,//Extended Memories
-    'C' : 0xB0,//CIO
-    'W' : 0xB1,//Work Area
-    'H' : 0xB2,//Holding Bit
-    'A' : 0xB3,//Auxiliary Bit
-    'D' : 0x82//Data Memories
+    'E'  : 0xA0,//Extended Memories
+    'C'  : 0xB0,//CIO
+    'CB' : 0x30,//CIO reading in bit
+    'W'  : 0xB1,//Work Area
+    'WB' : 0x31,//Work Area reading in bit
+    'H'  : 0xB2,//Holding Bit
+    'HB' : 0x32,//Holding Bit reading in bit
+    'A'  : 0xB3,//Auxiliary Bit
+    'AB' : 0x33,//Auxiliary Bit reading in bit
+    'D'  : 0x82,//Data Memories
+    'DM' : 0x02//Data Memories reading in bit
 };
 
 module.exports.Errors = {

--- a/lib/fins_client.js
+++ b/lib/fins_client.js
@@ -307,7 +307,7 @@ FinsClient.prototype.read = function(address,regsToRead,callback) {
     var command = constants.Commands.MEMORY_AREA_READ;
     var commandData = [address,regsToRead];
     var packet = _buildPacket([header,command,commandData]);
-    var buffer = new Buffer(packet);
+    var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
 };
 
@@ -360,7 +360,7 @@ FinsClient.prototype.write = function(address,dataToBeWritten,callback) {
     var address = _translateMemoryAddress(address);
     var commandData = [address,regsToWrite,dataToBeWritten];
     var packet = _buildPacket([header,command,commandData]);
-    var buffer = new Buffer(packet);
+    var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
 };
 
@@ -374,7 +374,7 @@ FinsClient.prototype.fill = function(address,dataToBeWritten,regsToWrite,callbac
     var dataToBeWritten = _wordsToBytes(dataToBeWritten);
     var commandData = [address,regsToWrite,dataToBeWritten];
     var packet = _buildPacket([header,command,commandData]);
-    var buffer = new Buffer(packet);
+    var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
 };
 
@@ -384,7 +384,7 @@ FinsClient.prototype.run = function(callback) {
     var header = _buildHeader(self.header);
     var command = constants.Commands.RUN;
     var packet = _buildPacket([header,command]);
-    var buffer = new Buffer(packet);
+    var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
 };
 
@@ -394,7 +394,7 @@ FinsClient.prototype.stop = function(callback) {
     var header = _buildHeader(self.header);
     var command = constants.Commands.STOP;
     var packet = _buildPacket([header,command]);
-    var buffer = new Buffer(packet);
+    var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
 };
 
@@ -405,7 +405,7 @@ FinsClient.prototype.status = function(callback) {
     var header = _buildHeader(self.header);
     var command = constants.Commands.CONTROLLER_STATUS_READ;
     var packet = _buildPacket([header,command]);
-    var buffer = new Buffer(packet);
+    var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
 };
 

--- a/lib/fins_client.js
+++ b/lib/fins_client.js
@@ -2,6 +2,7 @@ var dgram = require('dgram');
 var inherits = require('util').inherits;
 var EventEmitter = require('events').EventEmitter;
 var constants = require('./constants');
+var isBit = []; // array to hold whether an SID read is a bit or a word
 
 module.exports = FinsClient;
 
@@ -69,29 +70,35 @@ _wordsToBytes = function(words) {
 };
 
 
-_translateMemoryAddress = function(memoryAddress) {
-    var re = /(.)([0-9]*):?([0-9]*)/;
+_translateMemoryAddress = function(memoryAddress, sid) {
+    var re = /([A-Z]*)([0-9]*):?([0-9]*)/;
     var matches = memoryAddress.match(re);
-    var decodedMemory = {
-        'MemoryArea':matches[1],
-        'Address':matches[2],
-        'Bit':matches[3]
-    };
-
+    var area = matches[1];
+    var addr = matches[2];
+    var bit  = matches[3];
     var temp = [];
-    var byteEncodedMemory = [];
 
-    if(!constants.MemoryAreas[decodedMemory['MemoryArea']]) {
+    if(!constants.MemoryAreas[area]) {
         temp.push([0x82]);
     } else {
-         temp.push([constants.MemoryAreas[decodedMemory['MemoryArea']]]);
+        temp.push(constants.MemoryAreas[area]);
     }
 
-     temp.push(_wordsToBytes([decodedMemory['Address']]));
-     temp.push([0x00]);
-     byteEncodedMemory = _mergeArrays(temp);
+    temp.push(_wordsToBytes([addr]));
 
-    return byteEncodedMemory;
+    if (bit) {
+      isBit[sid]=true;
+    }
+    else{
+      isBit[sid]=false;
+      bit = 0x00;
+    }
+
+    bit &= 0x0f;
+
+    temp.push(bit);
+
+    return _mergeArrays(temp);
 };
 
 _incrementSID = function(sid) {
@@ -173,12 +180,42 @@ _processMemoryAreaRead = function(buf,rinfo) {
     var command = (buf.slice(10,12)).toString("hex");
     var response = (buf.slice(12,14)).toString("hex");
     var values = (buf.slice(14,buf.length));
-    for(var i = 0; i < values.length; i+=2) {
+    var step = isBit[sid] ? 1 : 2;
+
+    for(var i = 0; i < values.length; i+=step) {
+      if(isBit[sid]){
+        data.push(values.readInt8(i));
+      }
+      else{
         data.push(values.readInt16BE(i));
+      }
     }
     return {remotehost:rinfo.address,sid:sid,command:command,response:response,values:data};
 };
 
+
+_processMemoryAreaReadMultiple = function(buf,rinfo) {
+    var bits = ['30','31','32','33','B2','B3']; // hex values of memory addresses we support which read a bit
+    var data = [];
+    var sid = buf[9];
+    var command = (buf.slice(10,12)).toString("hex");
+    var response = (buf.slice(12,14)).toString("hex");
+    var values = (buf.slice(14,buf.length));
+
+    for(var i=0; i<values.length;){
+      var memarea = values[i++].toString(16); // get the HEX value of the mem area
+
+      if(bits.includes(memarea)){ // if we read a bit only read one element of the buffer
+        data.push(values.readInt8(i)); // not sure if readInt8() is needed, could we just push values[i] instead
+        i++; // move to the next memory area
+      }
+      else{
+        data.push(values.readInt16BE(i));
+        i=i+2; // move to the next memory area
+      }
+    }
+    return {remotehost:rinfo.address,sid:sid,command:command,response:response,values:data};
+};
 
 _processReply = function(buf,rinfo) {
     var commands = constants.Commands;
@@ -193,11 +230,17 @@ _processReply = function(buf,rinfo) {
             return _processMemoryAreaRead(buf,rinfo);
             break;
 
+        case commands.MEMORY_AREA_READ_MULTI.join(' '):
+            return _processMemoryAreaReadMultiple(buf,rinfo);
+            break;
+
         default:
             return _processDefault(buf,rinfo);
     };
 
 };
+
+
 _decodePacket = function(buf,rinfo) {
     var data = [];
     var command = (buf.slice(10,12)).toString("hex");
@@ -259,7 +302,7 @@ FinsClient.prototype.read = function(address,regsToRead,callback) {
     var self = this;
     self.header.SID = _incrementSID(self.header.SID);
     var header = _buildHeader(self.header);
-    var address = _translateMemoryAddress(address);
+    var address = _translateMemoryAddress(address, self.header.SID);
     var regsToRead = _wordsToBytes(regsToRead);
     var command = constants.Commands.MEMORY_AREA_READ;
     var commandData = [address,regsToRead];
@@ -268,14 +311,53 @@ FinsClient.prototype.read = function(address,regsToRead,callback) {
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
 };
 
+FinsClient.prototype.readMultiple = function() { // no callback not sure how to handle this with an unknown number of arguments
+    var self = this;
+    self.header.SID = _incrementSID(self.header.SID);
+    var header = _buildHeader(self.header);
+    var command = constants.Commands.MEMORY_AREA_READ_MULTI;
+    var commandData = []; // tmp array to push all the arguments memory address onto
+    for(i=0; i<arguments.length;i++){
+      commandData.push(_translateMemoryAddress(arguments[i]));
+    }
+    var packet = _buildPacket([header,command,commandData]);
+    var buffer = Buffer.from(packet);
+    this.socket.send(buffer,0,buffer.length,self.port,self.host); // we do not return a callback
+};
+
+FinsClient.prototype.transfer = function(sourceAddress,destAddress,regsToRead,callback) {
+    var self = this;
+    self.header.SID = _incrementSID(self.header.SID);
+    var header = _buildHeader(self.header);
+    var sourceAddress = _translateMemoryAddress(sourceAddress, self.header.SID);
+    var destAddress = _translateMemoryAddress(destAddress, self.header.SID);
+    var regsToRead = _wordsToBytes(regsToRead);
+    var command = constants.Commands.MEMORY_AREA_TRANSFER;
+    var commandData = [sourceAddress,destAddress,regsToRead];
+    var packet = _buildPacket([header,command,commandData]);
+    var buffer = Buffer.from(packet);
+    this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
+};
+
 FinsClient.prototype.write = function(address,dataToBeWritten,callback) {
     var self = this;
     self.header.SID = _incrementSID(self.header.SID);
     var header = _buildHeader(self.header);
-    var address = _translateMemoryAddress(address);
-    var regsToWrite = _wordsToBytes((dataToBeWritten.length || 1));
     var command = constants.Commands.MEMORY_AREA_WRITE;
-    var dataToBeWritten = _wordsToBytes(dataToBeWritten);
+    var regsToWrite = _wordsToBytes((dataToBeWritten.length || 1));
+
+    // if address matches a bit, has a 2 character memory address eg HB, we validate the data to be written
+    if(address.match( /([A-Z]){2}([0-9]*)/ )){
+        if(dataToBeWritten>1){
+	  console.log("Exiting before attempting to write: Bits can only be 0=0FF or 1=ON");
+          process.exit(1);
+        }
+    }
+    else{
+      var dataToBeWritten = _wordsToBytes(dataToBeWritten); // convert data to be written to a word
+    }
+
+    var address = _translateMemoryAddress(address);
     var commandData = [address,regsToWrite,dataToBeWritten];
     var packet = _buildPacket([header,command,commandData]);
     var buffer = new Buffer(packet);
@@ -333,5 +415,5 @@ FinsClient.prototype.close = function(){
         clearTimeout(this.timer);
         this.timer = undefined;
     }
-	this.socket.close();
+    this.socket.close();
 };

--- a/lib/fins_client.js
+++ b/lib/fins_client.js
@@ -241,18 +241,6 @@ _processReply = function(buf,rinfo) {
 };
 
 
-_decodePacket = function(buf,rinfo) {
-    var data = [];
-    var command = (buf.slice(10,12)).toString("hex");
-    var code = (buf.slice(12,14)).toString("hex");
-    var values = (buf.slice(14,buf.length));
-    for(var i = 0; i < values.length; i+=2) {
-        data.push(values.readInt16BE(i));
-    }
-    return {remotehost:rinfo.address,command:command,code:code,values:data};
-};
-
-
 FinsClient.init = function (port,host,options) {
     var self = this;
     var defaultHost = constants.DefaultHostValues;

--- a/lib/fins_client.js
+++ b/lib/fins_client.js
@@ -47,7 +47,6 @@ _keyFromValue = function(dict,value) {
     return key;
 };
 
-  
 
 _padHex = function (width,number) {
     return("0"*width + number.toString(16).substr(-width));
@@ -67,12 +66,11 @@ _wordsToBytes = function(words) {
         }
     }
     return bytes;
-
 };
 
 
 _translateMemoryAddress = function(memoryAddress) {
-    var re = /(.)([0-9]*):?([0-9]*)/; 
+    var re = /(.)([0-9]*):?([0-9]*)/;
     var matches = memoryAddress.match(re);
     var decodedMemory = {
         'MemoryArea':matches[1],
@@ -94,8 +92,6 @@ _translateMemoryAddress = function(memoryAddress) {
      byteEncodedMemory = _mergeArrays(temp);
 
     return byteEncodedMemory;
-
-  
 };
 
 _incrementSID = function(sid) {
@@ -113,10 +109,9 @@ _buildHeader = function(header) {
         header.SNA,
         header.SA1,
         header.SA2,
-        header.SID 
+        header.SID
     ];
     return builtHeader;
-
 };
 
 _buildPacket = function(raw) {
@@ -126,7 +121,6 @@ _buildPacket = function(raw) {
 };
 
 _getResponseType = function(buf) {
-    
     var response = [];
     response.push(buf[10]);
     response.push(buf[11]);
@@ -138,7 +132,6 @@ _processDefault = function(buf,rinfo) {
     var command = (buf.slice(10,12)).toString("hex");
     var response = (buf.slice(12,14)).toString("hex");
     return {remotehost:rinfo.address,sid:sid,command:command,response:response};
-
 };
 
 _processStatusRead = function(buf,rinfo) {
@@ -148,7 +141,7 @@ _processStatusRead = function(buf,rinfo) {
     var status = buf[14];
     var mode = buf[15];
     var fatalErrorData = {};
-    var nonFatalErrorData = {};    
+    var nonFatalErrorData = {};
     for(var i in constants.FatalErrorData) {
         if((buf.readInt16BE(17) & constants.FatalErrorData[i]) !=0 )
             fatalErrorData.push(i);
@@ -190,10 +183,9 @@ _processMemoryAreaRead = function(buf,rinfo) {
 _processReply = function(buf,rinfo) {
     var commands = constants.Commands;
     var responseType = (_getResponseType(buf)).join(' ');
-    
+
     switch(responseType) {
-       
-        case commands.CONTROLLER_STATUS_READ.join(' ') : 
+        case commands.CONTROLLER_STATUS_READ.join(' '):
             return _processStatusRead(buf,rinfo);
             break;
 
@@ -203,7 +195,6 @@ _processReply = function(buf,rinfo) {
 
         default:
             return _processDefault(buf,rinfo);
-
     };
 
 };
@@ -254,8 +245,9 @@ FinsClient.init = function (port,host,options) {
     this.socket.on('error',error);
 
     if(this.timeout){
-        setTimeout(function cb_setTimeout() {
+        this.timer = setTimeout(function cb_setTimeout() {
             if(self.responded == false){
+                self.timer = undefined;
                 self.emit('timeout',self.host);
             }
         },self.timeout);
@@ -333,13 +325,13 @@ FinsClient.prototype.status = function(callback) {
     var packet = _buildPacket([header,command]);
     var buffer = new Buffer(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
-
-
 };
 
 
 FinsClient.prototype.close = function(){
-    this.socket.close();
+    if (this.timer) {
+        clearTimeout(this.timer);
+        this.timer = undefined;
+    }
+	this.socket.close();
 };
-
-


### PR DESCRIPTION
This replaces PR #17 

Add support for reading bits
Add support for writing bits
Add support for reading multiple memory areas (it handles both bits and words in one command)
Migrate to safe Buffer constructor methods (removes the warning messages)

I have updated the README and exmaples/basic.js to show the usage. I can provide Wireshark logs if you require them.