### PR TITLE
functions return SID value for matching the reply

### DIFF
--- a/lib/fins_client.js
+++ b/lib/fins_client.js
@@ -297,6 +297,7 @@ FinsClient.prototype.read = function(address,regsToRead,callback) {
     var packet = _buildPacket([header,command,commandData]);
     var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
+    return self.header.SID;
 };
 
 FinsClient.prototype.readMultiple = function() { // no callback not sure how to handle this with an unknown number of arguments
@@ -311,6 +312,7 @@ FinsClient.prototype.readMultiple = function() { // no callback not sure how to 
     var packet = _buildPacket([header,command,commandData]);
     var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host); // we do not return a callback
+    return self.header.SID;
 };
 
 FinsClient.prototype.transfer = function(sourceAddress,destAddress,regsToRead,callback) {
@@ -325,6 +327,7 @@ FinsClient.prototype.transfer = function(sourceAddress,destAddress,regsToRead,ca
     var packet = _buildPacket([header,command,commandData]);
     var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
+    return self.header.SID;
 };
 
 FinsClient.prototype.write = function(address,dataToBeWritten,callback) {
@@ -337,8 +340,7 @@ FinsClient.prototype.write = function(address,dataToBeWritten,callback) {
     // if address matches a bit, has a 2 character memory address eg HB, we validate the data to be written
     if(address.match( /([A-Z]){2}([0-9]*)/ )){
         if(dataToBeWritten>1){
-	  console.log("Exiting before attempting to write: Bits can only be 0=0FF or 1=ON");
-          process.exit(1);
+          throw new Error("Bits can only be 0 (Off) or 1 (On)");
         }
     }
     else{
@@ -350,6 +352,7 @@ FinsClient.prototype.write = function(address,dataToBeWritten,callback) {
     var packet = _buildPacket([header,command,commandData]);
     var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
+    return self.header.SID;
 };
 
 FinsClient.prototype.fill = function(address,dataToBeWritten,regsToWrite,callback) {
@@ -364,6 +367,7 @@ FinsClient.prototype.fill = function(address,dataToBeWritten,regsToWrite,callbac
     var packet = _buildPacket([header,command,commandData]);
     var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
+    return self.header.SID;
 };
 
 FinsClient.prototype.run = function(callback) {
@@ -374,6 +378,7 @@ FinsClient.prototype.run = function(callback) {
     var packet = _buildPacket([header,command]);
     var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
+    return self.header.SID;
 };
 
 FinsClient.prototype.stop = function(callback) {
@@ -384,6 +389,7 @@ FinsClient.prototype.stop = function(callback) {
     var packet = _buildPacket([header,command]);
     var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
+    return self.header.SID;
 };
 
 
@@ -395,6 +401,7 @@ FinsClient.prototype.status = function(callback) {
     var packet = _buildPacket([header,command]);
     var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
+    return self.header.SID;
 };
 
 


### PR DESCRIPTION
Functions return the `header.SID` value in order to correctly match the sent command with the reply.

Example code: 

```ls
export class OmronFinsDriver extends DriverAbstract
    (@opts={}) ->
        super!
        @log = new Logger \OmronFinsDriver
        @target = {port: 9600, host: '192.168.250.1'} <<< @opts
        @timeout = 2000ms  # 100ms

        @log.log bg-yellow "Using #{@target.host}:#{@target.port}"
        @client = fins.FinsClient @target.port, @target.host

        @q = {} # exec queue. Key field is the sequence number (FinsClient.SID).

        @client.on \reply, (msg) ~>
            if msg.sid of @q
                # got an expected reply
                @q[msg.sid].go err=null, res=msg 
                delete @q[msg.sid]
            else 
                @log.error "Unexpected response: (none in #{Object.keys @q}):", msg

        @client.on \error, (err) ~> 
            @log.error "FINS Client error:", err 

        @client.on \timeout, (err) ~> 
            @log.error "FINS timeout:", err

        # PLC connection status 
        @connected = no 
        @on \connected, ~> 
            @log.info "Connected to PLC"
        @on \disconnected, ~> 
            @log.info "Disconnected from PLC"

        @check-heartbeating!


    check-heartbeating: ->>
        @log.log "Starting the heartbeat check with the PLC"
        while true
            try await @exec \read, "C0:0", 1
            await sleep 10_000ms
   
    exec: (command, ...args) ->> 
        # This is the key function that transforms the discrete .read/.write functions 
        # into async functions        
        SID = @client[command] ...args
        @q[SID] = new Signal!
        return new Promise (resolve, reject) ~>
            @q[SID].wait @timeout, (err, res) ~> 
                if err 
                    reject(err)
                    @trigger \disconnected if @connected
                    @connected = no 
                    sleep 0 ~> 
                        delete @q[SID] if SID of @q
                else 
                    resolve(res)
                    @trigger \connected unless @connected
                    @connected = yes
```

This is the current code I'm using for as a wrapper class. I use this driver as follows: 

```ls
driver = new OmronFinsDriver()
try 
    value = await driver.exec 'read', 'DM0:0', 1
catch 
    console.error "Something went wrong while reading"

# or 

try
    await driver.exec 'write', 'DM0:0', 1
catch
  console.error "Something went wrong while writing"
```

In order to make this kind of usage possible, I need to match the sent command with the reply. Here the `SID` value plays a key role. Thereby, functions must return the SID value they are using in order to let us match the sent command with its reply. 